### PR TITLE
replaced all instances of Block to Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oya Contracts
 
-`oyaprotocol/contracts` is the smart contract suite for **Oya**, a natural language protocol. Assets deposited into these smart contracts on existing EVM chains can be used on the Oya natural language protocol. Blocks of transactions in the Oya protocol are verified using [UMA’s Optimistic Oracle](https://umaproject.org/), ensuring decentralized, permissionless validation of block data and proposals.
+`oyaprotocol/contracts` is the smart contract suite for **Oya**, a natural language protocol. Assets deposited into these smart contracts on existing EVM chains can be used on the Oya natural language protocol. Bundles of transactions in the Oya protocol are verified using [UMA’s Optimistic Oracle](https://umaproject.org/), ensuring decentralized, permissionless validation of bundle data and proposals.
 
 > _“Oya is a protocol that interprets natural language rules and transactions, enabling a new paradigm for decentralized applications, ideal for both humans and AI.”_
 
@@ -11,7 +11,7 @@
 - [Overview](#overview)
 - [Architecture](#architecture)
   - [OptimisticProposer](#optimisticproposer)
-  - [BlockTracker](#blocktracker)
+  - [BundleTracker](#bundletracker)
   - [VaultTracker](#vaulttracker)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
@@ -27,7 +27,7 @@
 This repository contains the Solidity smart contracts that enable a natural language protocol by integrating with UMA’s Optimistic Oracle for dispute resolution. The main components include:
 
 - **OptimisticProposer:** Provides a reusable framework for proposing and verifying onchain transactions or proposals via UMA’s optimistic validation mechanism.
-- **BlockTracker:** Handles the proposal of new blocks (with natural language-based block data) and integrates with UMA’s Optimistic Oracle to verify the proposals.
+- **BundleTracker:** Handles the proposal of new bundles (with natural language-based bundle data) and integrates with UMA’s Optimistic Oracle to verify the proposals.
 - **VaultTracker:** Manages vaults that control assets deposited into the smart contracts. It enables vault creation, management (controllers, guardians), and protocol-level freeze/unfreeze functionality.
 
 Together, these contracts allow any ERC20 or ERC721 assets on existing EVM chains to be bridged to the Oya protocol and governed by natural language rules.
@@ -42,14 +42,14 @@ The `OptimisticProposer` contract is a core component that abstracts the interac
 - Support for dispute resolution callbacks (e.g., automatic deletion of disputed proposals).
 - Functions to set global rules, liveness periods, and identifiers used to validate proposals.
 
-This contract is inherited by both the `BlockTracker` and `VaultTracker`, ensuring consistent behavior when proposing and validating assertions.
+This contract is inherited by both the `BundleTracker` and `VaultTracker`, ensuring consistent behavior when proposing and validating assertions.
 
-### BlockTracker
+### BundleTracker
 
-The `BlockTracker` contract is responsible for tracking new blocks on the Oya natural language protocol. Key features include:
-- **Block Proposal:** Nodes can propose new blocks by submitting natural language block data.
-- **Optimistic Verification:** Each block proposal triggers an assertion via UMA’s Optimistic Oracle. If the assertion is validated, the block is finalized.
-- **Event Emission:** Emits events such as `BlockProposed` and `BlockTrackerDeployed` for offchain monitoring and integration.
+The `BundleTracker` contract is responsible for tracking new bundles on the Oya natural language protocol. Key features include:
+- **Bundle Proposal:** Nodes can propose new bundles by submitting natural language bundle data.
+- **Optimistic Verification:** Each bundle proposal triggers an assertion via UMA’s Optimistic Oracle. If the assertion is validated, the bundle is finalized.
+- **Event Emission:** Emits events such as `BundleProposed` and `BundleTrackerDeployed` for offchain monitoring and integration.
 
 ### VaultTracker
 
@@ -91,20 +91,20 @@ The contracts are designed to be deployed on EVM-compatible chains. Deployment i
    - Choose the liveness period for assertions.
 
 2. **Deploying Contracts:**
-   - Deploy the `OptimisticProposer`-based contracts (e.g., `BlockTracker` and `VaultTracker`).
+   - Deploy the `OptimisticProposer`-based contracts (e.g., `BundleTracker` and `VaultTracker`).
    - Ensure the UMA Optimistic Oracle’s address is correctly synced via the `_sync()` functions.
 
 Example deployment using Foundry:
 
 ```bash
-# Deploy BlockTracker
+# Deploy BundleTracker
 RULES="$(cat ./rules/global.txt)"
 forge create \
   --etherscan-api-key <etherscan-api-key> --verify \
   --constructor-args <finderAddress> <collateralAddress> <bondAmount> "<rules>" <identifier> <liveness> \
   --rpc-url <your_rpc_url> \
   --private-key <your_private_key> \
-  src/implementation/BlockTracker.sol:BlockTracker
+  src/implementation/BundleTracker.sol:BundleTracker
 
 # Deploy VaultTracker
 RULES="$(cat ./rules/global.txt)"
@@ -120,14 +120,14 @@ Replace the constructor arguments, Etherscan API key, RPC URL, and private key w
 
 ## Usage
 
-### Proposing a Block
+### Proposing a Bundle
 
-Users interact with the `BlockTracker` contract by calling the `proposeBlock` function with their block data written in natural language. The data structure is described in the protocol's global rules. The process is as follows:
+Users interact with the `BundleTracker` contract by calling the `proposeBundle` function with their bundle data written in natural language. The data structure is described in the protocol's global rules. The process is as follows:
 
-- The contract records the block proposal along with the current timestamp and the proposer's address.
-- UMA’s Optimistic Oracle is invoked to assert the truthfulness of the block proposal.
-- A `BlockProposed` event is emitted containing the timestamp, proposer address, and block data.
-- If the assertion is validated (i.e., no disputes are raised within the liveness period), the block is finalized.
+- The contract records the bundle proposal along with the current timestamp and the proposer's address.
+- UMA’s Optimistic Oracle is invoked to assert the truthfulness of the bundle proposal.
+- A `BundleProposed` event is emitted containing the timestamp, proposer address, and bundle data.
+- If the assertion is validated (i.e., no disputes are raised within the liveness period), the bundle is finalized.
 
 ### Managing Vaults
 
@@ -143,7 +143,7 @@ The `VaultTracker` contract provides methods to manage vaults, which hold the br
 
 ### Interacting with UMA’s Optimistic Oracle
 
-Both the `BlockTracker` and `VaultTracker` rely on UMA’s Optimistic Oracle for dispute resolution:
+Both the `BundleTracker` and `VaultTracker` rely on UMA’s Optimistic Oracle for dispute resolution:
 
 - After a proposal is asserted, if no disputes arise during the liveness period, the proposal is considered valid and can be executed.
 - If a dispute occurs, the relevant callbacks (such as `assertionDisputedCallback` or `assertionResolvedCallback`) handle the resolution by deleting or finalizing the proposal.
@@ -153,7 +153,7 @@ For more details on interacting with UMA’s Optimistic Oracle, please refer to 
 ## Testing
 
 Our tests are located in the `./test/` directory, with the following files:
-- `BlockTracker.t.sol`
+- `BundleTracker.t.sol`
 - `OptimisticProposer.t.sol`
 - `VaultTracker.t.sol`
 
@@ -172,7 +172,7 @@ forge test -vv
 
 These tests cover key functionalities, including:
 
-* Block proposal and finalization in `BlockTracker`.
+* Bundle proposal and finalization in `BundleTracker`.
 * Transaction proposals and execution in `OptimisticProposer`.
 * Vault management, including freezing/unfreezing and role assignments in `VaultTracker`.
 

--- a/src/implementation/BundleTracker.sol
+++ b/src/implementation/BundleTracker.sol
@@ -1,0 +1,138 @@
+pragma solidity ^0.8.6;
+
+import "./OptimisticProposer.sol";
+
+/**
+ * @title Bundle Tracker
+ * @notice Extends OptimisticProposer for timestamped bundle data proposals
+ * @dev Specialized contract for tracking and validating OyaProtocol 'bundle' data
+ *
+ * @custom:invariant lastFinalizedTimestamp <= block.timestamp
+ * @custom:invariant For any stored assertionId, assertionTimestamps[assertionId] equals the proposal timestamp
+ */
+contract BundleTracker is OptimisticProposer {
+  /// @notice Emitted when a new bundle is proposed for validation
+  /// @param timestamp The timestamp when the bundle was proposed
+  /// @param bundleProposer Address that proposed the bundle data
+  /// @param bundleData The bundle data being validated
+  event BundleProposed(uint256 indexed timestamp, address indexed bundleProposer, string bundleData);
+
+  /// @notice Emitted when the BundleTracker contract is deployed and initialized
+  /// @param rules The protocol rules used for bundle validation
+  event BundleTrackerDeployed(string rules);
+
+  /// @notice Timestamp of the last bundle that was finalized through optimistic validation
+  /// @dev Updated when assertions resolve truthfully
+  uint256 public lastFinalizedTimestamp;
+
+  /// @notice Maps assertion IDs to their proposal timestamps
+  /// @dev Used to track when bundles were proposed for validation
+  mapping(bytes32 => uint256) public assertionTimestamps;
+
+  /// @notice Maps assertion IDs to their proposers
+  /// @dev Tracks who proposed each bundle for accountability
+  mapping(bytes32 => address) public assertionProposer;
+
+  /// @notice Maps timestamps and proposers to their proposed bundle data
+  /// @dev Retrieval requires both the proposal timestamp and proposer address
+  mapping(uint256 => mapping(address => string)) public bundles;
+
+  /**
+   * @notice Initializes the BundleTracker contract
+   * @param _finder Address of the UMA Finder contract
+   * @param _collateral Address of the collateral ERC20 token
+   * @param _bondAmount Base bond amount for bundle proposals
+   * @param _rules Protocol rules for bundle validation
+   * @param _identifier UMA identifier for proposal validation
+   * @param _liveness Dispute window for bundle proposals
+   * @dev Calls setUp with encoded parameters for proxy compatibility
+   */
+  constructor(
+    address _finder,
+    address _collateral,
+    uint256 _bondAmount,
+    string memory _rules, // Oya global rules
+    bytes32 _identifier,
+    uint64 _liveness
+  ) {
+    require(_finder != address(0), "Finder address can not be empty");
+    finder = FinderInterface(_finder);
+    bytes memory initializeParams = abi.encode(_collateral, _bondAmount, _rules, _identifier, _liveness);
+    setUp(initializeParams);
+  }
+
+  /**
+   * @notice Initializes the contract state with provided parameters
+   * @param initializeParams Encoded initialization parameters
+   * @dev Decodes and sets up collateral, rules, identifier, and liveness
+   * @custom:events Emits BundleTrackerDeployed event
+   */
+  function setUp(bytes memory initializeParams) public initializer {
+    _startReentrantGuardDisabled();
+    __Ownable_init();
+    (
+      address _collateral,
+      uint256 _bondAmount,
+      string memory _rules,
+      bytes32 _identifier,
+      uint64 _liveness
+    ) = abi.decode(initializeParams, (address, uint256, string, bytes32, uint64));
+    setCollateralAndBond(IERC20(_collateral), _bondAmount);
+    setRules(_rules);
+    setIdentifier(_identifier);
+    setLiveness(_liveness);
+    _sync();
+
+    emit BundleTrackerDeployed(_rules);
+  }
+
+  /**
+   * @notice Proposes bundle data for optimistic validation
+   * @param _bundleData String representation of bundle data to be validated
+   * @dev Creates an assertion for bundle data validity at current timestamp. The claim asserted to
+   *      the Optimistic Oracle V3 is the raw `_bundleData` bytes (no additional keys/rules encoding).
+   *
+   * Process:
+   * 1. Stores bundle data with timestamp and proposer
+   * 2. Creates optimistic assertion for data validity
+   * 3. Tracks assertion for later resolution
+   *
+   * @custom:events Emits BundleProposed with timestamp and proposer details
+   * @custom:security Requires the proposer to approve at least `bondAmount` collateral for this contract.
+   *                  The oracle enforces a minimum bond; if `bondAmount` is below the minimum, the
+   *                  assertion will revert unless configuration is adjusted accordingly.
+   */
+  function proposeBundle(string memory _bundleData) external {
+    bundles[block.timestamp][msg.sender] = _bundleData;
+
+    bytes32 _assertionID = optimisticOracleV3.assertTruth(
+      bytes(_bundleData),
+      msg.sender,
+      address(this), // callback to the bundle tracker contract
+      address(0), // no escalation manager
+      liveness, // these and other oracle values set in OptimisticProposer setup
+      collateral,
+      bondAmount,
+      identifier,
+      0
+    );
+
+    assertionProposer[_assertionID] = msg.sender;
+    assertionTimestamps[_assertionID] = block.timestamp;
+
+    emit BundleProposed(block.timestamp, msg.sender, _bundleData);
+  }
+
+  /**
+   * @notice Callback for resolved bundle data assertions
+   * @param assertionId The ID of the resolved assertion
+   * @param assertedTruthfully Whether the bundle data was validated as truthful
+   * @dev Updates lastFinalizedTimestamp if assertion resolved truthfully
+   * @custom:security Only callable by the Optimistic Oracle V3 contract
+   */
+  function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public override {
+    require(msg.sender == address(optimisticOracleV3));
+    if (assertedTruthfully) lastFinalizedTimestamp = assertionTimestamps[assertionId];
+  }
+
+}

--- a/test/BundleTracker.t.sol
+++ b/test/BundleTracker.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.6;
+
+import "forge-std/Test.sol";
+import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+
+import "@uma/core/optimistic-oracle-v3/interfaces/EscalationManagerInterface.sol";
+import "../src/implementation/BundleTracker.sol";
+import "../src/mocks/MockAddressWhitelist.sol";
+import "../src/mocks/MockERC20.sol";
+import "../src/mocks/MockFinder.sol";
+import "../src/mocks/MockIdentifierWhitelist.sol";
+import "../src/mocks/MockOptimisticOracleV3.sol";
+
+contract BundleTrackerTest is Test {
+    BundleTracker public bundleTracker;
+    MockFinder public mockFinder;
+    MockAddressWhitelist public mockAddressWhitelist;
+    MockIdentifierWhitelist public mockIdentifierWhitelist;
+    MockOptimisticOracleV3 public mockOptimisticOracleV3;
+    MockERC20 public mockCollateral;
+    MockERC20 public newMockCollateral;
+    EscalationManagerInterface public mockEscalationManager;
+
+    address public owner         = address(1);
+    address public bundleProposer = address(2);
+    address public txProposer    = address(3); // For proposeTransactions
+    address public randomAddress = address(4);
+
+    uint256 public bondAmount = 1000;
+    string  public rules      = "Sample rules";
+    string  public newRules   = "New rules";
+
+    bytes32 public identifier = keccak256("Identifier");
+    bytes32 public newIdentifier = keccak256("AnotherIdentifier");
+    
+    uint64 public liveness    = 100;
+    uint64 public newLiveness = 200;
+
+    function setUp() public {
+        // Set up the mock contracts
+        mockFinder = new MockFinder();
+        mockAddressWhitelist = new MockAddressWhitelist();
+        mockIdentifierWhitelist = new MockIdentifierWhitelist();
+        mockOptimisticOracleV3 = new MockOptimisticOracleV3();
+        mockCollateral = new MockERC20();
+        newMockCollateral = new MockERC20();
+
+        // Setup the finder to return the mocks
+        mockFinder.changeImplementationAddress(OracleInterfaces.CollateralWhitelist, address(mockAddressWhitelist));
+        mockFinder.changeImplementationAddress(OracleInterfaces.IdentifierWhitelist, address(mockIdentifierWhitelist));
+        mockFinder.changeImplementationAddress(OracleInterfaces.OptimisticOracleV3, address(mockOptimisticOracleV3));
+
+        // Add collateral and identifier to the whitelist
+        mockAddressWhitelist.addToWhitelist(address(mockCollateral));
+        mockAddressWhitelist.addToWhitelist(address(newMockCollateral));
+        mockIdentifierWhitelist.addIdentifier(identifier);
+        mockIdentifierWhitelist.addIdentifier(newIdentifier);
+
+        // Deploy & initialize the BundleTracker contract from "owner" address
+        vm.startPrank(owner);
+        bundleTracker = new BundleTracker(
+            address(mockFinder),
+            address(mockCollateral),
+            bondAmount,
+            rules,
+            identifier,
+            liveness
+        );
+        vm.stopPrank();
+    }
+
+    // -----------------------------------------
+    // Tests for native BundleTracker functions
+    // -----------------------------------------
+
+    function testProposeBundle() public {
+        // Give bundleProposer some collateral to pay bond
+        mockCollateral.transfer(bundleProposer, 2000e18);
+
+        vm.startPrank(bundleProposer);
+        // Approve enough collateral for the bond
+        mockCollateral.approve(address(bundleTracker), 2000e18);
+
+        string memory bundleData = "Bundle data example";
+
+        // Propose the bundle
+        bundleTracker.proposeBundle(bundleData);
+
+        // The contract stores in: bundles[block.timestamp][msg.sender]
+        string memory storedData = bundleTracker.bundles(block.timestamp, bundleProposer);
+        assertEq(storedData, bundleData, "Bundle data not stored correctly");
+
+        vm.stopPrank();
+    }
+
+    // -----------------------------------------
+    // Tests for inherited OptimisticProposer functions
+    // -----------------------------------------
+
+    function testSetRules() public {
+        vm.startPrank(owner);
+        bundleTracker.setRules(newRules);
+        vm.stopPrank();
+
+        assertEq(bundleTracker.rules(), newRules, "Rules not updated");
+    }
+
+    function testSetIdentifier() public {
+        // Initially set to 'identifier'
+        assertEq(bundleTracker.identifier(), identifier);
+
+        vm.startPrank(owner);
+        bundleTracker.setIdentifier(newIdentifier);
+        vm.stopPrank();
+
+        assertEq(bundleTracker.identifier(), newIdentifier, "Identifier not updated");
+    }
+
+    function testSetLiveness() public {
+        // Initially set to 'liveness'
+        assertEq(bundleTracker.liveness(), liveness);
+
+        vm.startPrank(owner);
+        bundleTracker.setLiveness(newLiveness);
+        vm.stopPrank();
+
+        assertEq(bundleTracker.liveness(), newLiveness, "Liveness not updated");
+    }
+
+    function testSetEscalationManager() public {
+        vm.startPrank(owner);
+        bundleTracker.setEscalationManager(address(mockEscalationManager));
+        vm.stopPrank();
+
+        assertEq(bundleTracker.escalationManager(), address(mockEscalationManager), "Escalation manager not updated");
+    }
+
+    function testSetCollateralAndBond() public {
+        vm.startPrank(owner);
+        bundleTracker.setCollateralAndBond(IERC20(address(newMockCollateral)), bondAmount);
+        vm.stopPrank();
+
+        assertEq(address(bundleTracker.collateral()), address(newMockCollateral), "Collateral not updated");
+        assertEq(bundleTracker.bondAmount(), bondAmount, "Bond amount not updated");
+    }
+
+    function testProposeTransactions() public {
+        // Give txProposer some collateral to pay bond
+        mockCollateral.transfer(txProposer, 3000e18);
+
+        vm.startPrank(txProposer);
+        // Approve enough collateral for the bond
+        mockCollateral.approve(address(bundleTracker), 3000e18);
+
+        // Build a small set of transactions
+        OptimisticProposer.Transaction[] memory txs = new OptimisticProposer.Transaction[](2);
+
+        // transaction #1
+        txs[0] = OptimisticProposer.Transaction({
+            to: address(0x1234),
+            operation: Enum.Operation.Call,
+            value: 0,
+            data: ""
+        });
+
+        // transaction #2
+        txs[1] = OptimisticProposer.Transaction({
+            to: address(mockOptimisticOracleV3),
+            operation: Enum.Operation.Call,
+            value: 0,
+            data: "0x"
+        });
+
+        // propose transactions with some "explanation"
+        bundleTracker.proposeTransactions(txs, bytes("Hello world"));
+
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
## Summary
Refactors the Block tracking contract and related tests/docs to use "Bundle" semantics, aligning naming with protocol direction. Ethereum built-ins like `block.timestamp` remain unchanged. No vendored or generated files were modified.

## Changes

### Contracts
Updated `src/implementation/BlockTracker.sol` in-place:
- Contract: `BlockTracker` → `BundleTracker`
- Events:
  - `BlockProposed` → `BundleProposed`
  - `BlockTrackerDeployed` → `BundleTrackerDeployed`
- Public mapping:
  - `blocks` → `bundles`
- Function:
  - `proposeBlock(string _blockData)` → `proposeBundle(string _bundleData)`
- Parameters/locals/comments:
  - `blockData` → `bundleData`
  - `blockProposer` → `bundleProposer`
  - All docstrings and inline comments: "block" → "bundle" where not an Ethereum built-in
- Preserved Ethereum built-ins: `block.timestamp` unchanged
- changed name of file

### Tests
Updated `test/BlockTracker.t.sol` in-place:
- Contract: `BlockTrackerTest` → `BundleTrackerTest`
- Instance: `BlockTracker blockTracker` → `BundleTracker bundleTracker`
- Address: `blockProposer` → `bundleProposer`
- Test: `testProposeBlock()` → `testProposeBundle()`
- Calls and getters:
  - `proposeBlock(...)` → `proposeBundle(...)`
  - `blocks(...)` → `bundles(...)`
- Updated all inherited function calls to reference `bundleTracker`
- changed name of file

### Documentation
Updated root `README.md`:
- Renamed section and references:
  - "BlockTracker" → "BundleTracker"
  - "Block Proposal / blocks / BlockProposed / BlockTrackerDeployed" → "Bundle Proposal / bundles / BundleProposed / BundleTrackerDeployed"
- Deployment example target updated to `...:BundleTracker`
- Intro line updated from "Blocks of transactions..." to "Bundles of transactions..."
- Kept Ethereum built-ins unchanged; docs directory not edited

## Exclusions
- Did not change any Ethereum built-ins or EVM semantics (`block.timestamp`, `block.number`, `blockhash`).
- Did not modify generated artifacts under `out/**` or docs under `docs/**`.
- Did not touch vendored dependencies under `lib/**`.

## Testing
- Ran forge tests.
- All tests passed: