### PR TITLE
remove no-arg Ownable constructor from Oya token contract to fix build error

### DIFF
--- a/src/implementation/Oya.sol
+++ b/src/implementation/Oya.sol
@@ -27,7 +27,7 @@ contract Oya is ERC20, Ownable, ERC20Permit {
      * @dev Mints initial supply of 1 billion tokens to deployer
      * @custom:supply Initial supply is minted at deployment; additional supply can be minted by owner
      */
-  constructor() ERC20("Oya", "OYA") Ownable() ERC20Permit("Oya") {
+  constructor() ERC20("Oya", "OYA") ERC20Permit("Oya") {
     _mint(msg.sender, 1_000_000_000 * 10 ** decimals());
   }
 


### PR DESCRIPTION
Resolves this error when running `forge build`:

```
error: modifier-style base constructor call without arguments
  --> /Users/johnshutt/Code/contracts/src/implementation/Oya.sol:30:37
   |
30 |   constructor() ERC20("Oya", "OYA") Ownable() ERC20Permit("Oya") {
   |                                     ^^^^^^^^^
   |
```